### PR TITLE
RSCBC-303: Update hickory-resolver to 0.26.1

### DIFF
--- a/sdk/couchbase-connstr/Cargo.toml
+++ b/sdk/couchbase-connstr/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 
 [dependencies]
 form_urlencoded = "1.2"
-hickory-resolver = { version = "0.25.2", features = ["tokio", "system-config"], default-features = false, optional = true }
+hickory-resolver = { version = "0.26.1", features = ["tokio", "system-config"], default-features = false, optional = true }
 regex = "1.12"
 tracing = { version = "0.1.44", features = ["log"] }
 url = "2.5"

--- a/sdk/couchbase-connstr/src/error.rs
+++ b/sdk/couchbase-connstr/src/error.rs
@@ -42,7 +42,7 @@ pub enum ErrorKind {
     },
     Io(io::Error),
     #[cfg(feature = "dns-srv")]
-    Resolve(hickory_resolver::ResolveError),
+    Resolve(hickory_resolver::net::NetError),
 }
 
 impl Clone for ErrorKind {
@@ -89,8 +89,8 @@ impl From<io::Error> for Error {
 }
 
 #[cfg(feature = "dns-srv")]
-impl From<hickory_resolver::ResolveError> for Error {
-    fn from(e: hickory_resolver::ResolveError) -> Self {
+impl From<hickory_resolver::net::NetError> for Error {
+    fn from(e: hickory_resolver::net::NetError) -> Self {
         Self {
             kind: ErrorKind::Resolve(e),
         }

--- a/sdk/couchbase-connstr/src/lib.rs
+++ b/sdk/couchbase-connstr/src/lib.rs
@@ -26,9 +26,10 @@ use std::fmt::{Display, Formatter};
 use url::form_urlencoded;
 #[cfg(feature = "dns-srv")]
 use {
-    hickory_resolver::config::*, hickory_resolver::name_server::TokioConnectionProvider,
-    hickory_resolver::proto::xfer::Protocol, hickory_resolver::system_conf::read_system_conf,
-    hickory_resolver::TokioResolver, std::net::SocketAddr, std::time::Duration, tracing::debug,
+    hickory_resolver::config::*, hickory_resolver::net::runtime::TokioRuntimeProvider,
+    hickory_resolver::proto::rr::RData, hickory_resolver::system_conf::read_system_conf,
+    hickory_resolver::TokioResolver, std::io, std::net::SocketAddr, std::time::Duration,
+    tracing::debug,
 };
 
 pub const DEFAULT_LEGACY_HTTP_PORT: u16 = 8091;
@@ -430,13 +431,12 @@ async fn lookup_srv(
 ) -> error::Result<Vec<Address>> {
     let (resolver_config, resolver_opts) = match dns_config {
         Some(dns) => {
-            let mut group = NameServerConfigGroup::with_capacity(2);
-            let udp = NameServerConfig::new(dns.namespace, Protocol::Udp);
-            let tcp = NameServerConfig::new(dns.namespace, Protocol::Tcp);
-            group.push(udp);
-            group.push(tcp);
+            let mut ns_config = NameServerConfig::udp_and_tcp(dns.namespace.ip());
+            for conn in &mut ns_config.connections {
+                conn.port = dns.namespace.port();
+            }
 
-            let config = ResolverConfig::from_parts(None, vec![], group);
+            let config = ResolverConfig::from_name_servers(vec![ns_config]);
 
             let mut opts = ResolverOpts::default();
             if let Some(timeout) = dns.timeout {
@@ -445,23 +445,26 @@ async fn lookup_srv(
 
             (config, opts)
         }
-        None => read_system_conf().map_err(ErrorKind::Resolve)?,
+        None => read_system_conf().map_err(|e| ErrorKind::Io(io::Error::other(e.to_string())))?,
     };
 
     let resolver =
-        TokioResolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
+        TokioResolver::builder_with_config(resolver_config, TokioRuntimeProvider::default())
             .with_options(resolver_opts)
-            .build();
+            .build()
+            .map_err(ErrorKind::Resolve)?;
 
     let name = format!("_{scheme}._{proto}.{host}");
     let response = resolver.srv_lookup(name).await?;
 
     let mut addresses = vec![];
-    for addr in response.iter() {
-        addresses.push(Address {
-            host: addr.target().to_string(),
-            port: addr.port(),
-        });
+    for record in response.answers() {
+        if let RData::SRV(srv) = &record.data {
+            addresses.push(Address {
+                host: srv.target.to_string(),
+                port: srv.port,
+            });
+        }
     }
 
     Ok(addresses)
@@ -1098,5 +1101,65 @@ mod test {
             },
         )
         .await;
+    }
+
+    #[cfg(feature = "dns-srv")]
+    #[tokio::test]
+    async fn test_lookup_srv_against_mock_dns_server() {
+        use crate::DnsConfig;
+        use hickory_resolver::proto::op::{Message, OpCode};
+        use hickory_resolver::proto::rr::rdata::SRV;
+        use hickory_resolver::proto::rr::{Name, RData, Record};
+        use hickory_resolver::proto::serialize::binary::BinEncodable;
+        use std::str::FromStr;
+        use std::time::Duration;
+        use tokio::net::UdpSocket;
+
+        let target_host = "target.internal.example.";
+        let target_port = 11210u16;
+
+        let server_socket = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind mock DNS server");
+        let server_addr = server_socket.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let mut buf = [0u8; 512];
+            let Ok((len, client_addr)) = server_socket.recv_from(&mut buf).await else {
+                return;
+            };
+
+            let request = Message::from_vec(&buf[..len]).expect("failed to decode DNS query");
+            let query = request.queries[0].clone();
+
+            let mut response = Message::response(request.id, OpCode::Query);
+            response.add_query(query.clone());
+
+            let target = Name::from_str(target_host).unwrap();
+            let srv = SRV::new(0, 0, target_port, target);
+            let record = Record::from_rdata(query.name().clone(), 60, RData::SRV(srv));
+            response.add_answer(record);
+
+            let bytes = response.to_bytes().expect("failed to encode DNS response");
+            let _ = server_socket.send_to(&bytes, client_addr).await;
+        });
+
+        let conn_spec = parse_or_die("couchbase://myhost.internal.example");
+        let dns_config = DnsConfig {
+            namespace: server_addr,
+            timeout: Some(Duration::from_secs(2)),
+        };
+
+        let resolved = resolve(conn_spec, Some(dns_config))
+            .await
+            .expect("SRV resolution against the mock DNS server should succeed");
+
+        assert_eq!(
+            resolved.memd_hosts,
+            vec![Address {
+                host: target_host.to_string(),
+                port: target_port,
+            }]
+        );
     }
 }

--- a/sdk/couchbase-core/Cargo.toml
+++ b/sdk/couchbase-core/Cargo.toml
@@ -26,7 +26,7 @@ hmac = "0.12.1"
 http = "1.4"
 rand = "0.10.0"
 regex = "1.12"
-reqwest = { version = "0.13.2", features = ["json", "stream"], default-features = false }
+reqwest = { version = "0.13.4", features = ["json", "stream"], default-features = false }
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 snap = "1.1"


### PR DESCRIPTION
Changes
----------
- Update hickory-resolver to 0.26.1 to resolve RUSTSEC-2026-0119, and address relevant breaking changes introduced in 0.26
- Update minimum reqwest version